### PR TITLE
[BUG] : Fixed password inputs - inner border conflicts

### DIFF
--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -90,23 +90,45 @@ const Login = () => {
                         />
                     </div>
 
-                    <div className='grid gap-1'>
-                        <label htmlFor='password' className='dark:text-white'>Password :</label>
-                        <div className='bg-blue-50 dark:bg-neutral-800 dark:text-white p-2 border dark:border-neutral-700 rounded flex items-center focus-within:border-primary-200 dark:focus-within:border-primary-200'>
-                            <input
-                                type={showPassword ? "text" : "password"}
-                                id='password'
-                                className='w-full outline-none bg-transparent dark:placeholder-neutral-400'
-                                name='password'
-                                value={data.password}
-                                onChange={handleChange}
-                                placeholder='Enter your password'
-                            />
-                            <div onClick={() => setShowPassword(prev => !prev)} className='cursor-pointer'>
-                                {showPassword ? <FaRegEye /> : <FaRegEyeSlash />}
-                            </div>
-                        </div>
-                        <Link to={"/forgot-password"} className='block ml-auto hover:text-primary-200 dark:text-neutral-300 dark:hover:text-primary-200'>Forgot password ?</Link>
+                    <div className="grid gap-1">
+                    <label htmlFor="password" className="dark:text-white">Password :</label>
+                    <div className="bg-blue-50 dark:bg-neutral-800 dark:text-white p-2 border dark:border-neutral-700 rounded flex items-center focus-within:border-primary-200 dark:focus-within:border-primary-200">
+                        <input
+                        type={showPassword ? "text" : "password"}
+                        id="password"
+                        name="password"
+                        value={data.password}
+                        onChange={handleChange}
+                        placeholder="Enter your password"
+                        style={{
+                            background: "transparent",
+                            border: "0",
+                            outline: "0",
+                            padding: 0,
+                            margin: 0,
+                            boxShadow: "none",
+                            WebkitAppearance: "none",
+                            MozAppearance: "none",
+                            appearance: "none",
+                            width: "100%"
+                        }}
+                        className="w-full text-neutral-800 dark:text-white placeholder-neutral-500 dark:placeholder-neutral-400"
+                        />
+
+                        <button
+                        type="button"
+                        onClick={() => setShowPassword(prev => !prev)}
+                        className="ml-2 cursor-pointer text-neutral-600 dark:text-neutral-300 hover:text-primary-200 transition-colors"
+                        aria-label={showPassword ? "Hide password" : "Show password"}
+                        style={{ background: "transparent", border: 0, padding: 0 }}
+                        >
+                        {showPassword ? <FaRegEye /> : <FaRegEyeSlash />}
+                        </button>
+                    </div>
+
+                    <Link to="/forgot-password" className="block ml-auto hover:text-primary-200 dark:text-neutral-300 dark:hover:text-primary-200">
+                        Forgot password ?
+                    </Link>
                     </div>
 
                     <button disabled={!valideValue} className={` ${valideValue ? "bg-primary-100 hover:bg-primary-200" : "bg-gray-500"} text-white py-2 rounded font-semibold my-3 tracking-wide`}>Login</button>

--- a/client/src/pages/Register.jsx
+++ b/client/src/pages/Register.jsx
@@ -117,7 +117,19 @@ const Register = () => {
                             <input
                                 type={showPassword ? "text" : "password"}
                                 id='password'
-                                className='w-full outline-none bg-transparent dark:placeholder-neutral-400'
+                                style={{
+                                    background: "transparent",
+                                    border: "0",
+                                    outline: "0",
+                                    padding: 0,
+                                    margin: 0,
+                                    boxShadow: "none",
+                                    WebkitAppearance: "none",
+                                    MozAppearance: "none",
+                                    appearance: "none",
+                                    width: "100%"
+                                }}
+                                className="w-full text-neutral-800 dark:text-white placeholder-neutral-500 dark:placeholder-neutral-400"
                                 name='password'
                                 value={data.password}
                                 onChange={handleChange}
@@ -136,7 +148,19 @@ const Register = () => {
                             <input
                                 type={showConfirmPassword ? "text" : "password"}
                                 id='confirmPassword'
-                                className='w-full outline-none bg-transparent dark:placeholder-neutral-400'
+                                style={{
+                                    background: "transparent",
+                                    border: "0",
+                                    outline: "0",
+                                    padding: 0,
+                                    margin: 0,
+                                    boxShadow: "none",
+                                    WebkitAppearance: "none",
+                                    MozAppearance: "none",
+                                    appearance: "none",
+                                    width: "100%"
+                                }}
+                                className="w-full text-neutral-800 dark:text-white placeholder-neutral-500 dark:placeholder-neutral-400"
                                 name='confirmPassword'
                                 value={data.confirmPassword}
                                 onChange={handleChange}


### PR DESCRIPTION
fixed #7 
This pull request focuses on improving the styling and accessibility of password input fields in both the login and registration pages. The main changes include refactoring the input elements to use inline styles for better control, updating class names for consistency, and enhancing the password visibility toggle with a button for accessibility.

**Password Input Styling Improvements:**

* Refactored the password input in `Login.jsx` to use inline styles for a cleaner and more consistent look, and updated class names for better dark mode and placeholder support.
* Applied similar inline styling and updated class names to the password and confirm password inputs in `Register.jsx` for visual consistency across authentication forms. [[1]](diffhunk://#diff-85eb2088aee70cd64b77d6a9120ece25b21c0f21ddd905dcc4d76b2b2a5ca85bL120-R132) [[2]](diffhunk://#diff-85eb2088aee70cd64b77d6a9120ece25b21c0f21ddd905dcc4d76b2b2a5ca85bL139-R163)

**Accessibility and Usability Enhancements:**

* Replaced the password visibility icon in `Login.jsx` with a button element, adding an accessible label and improved focus/hover states for better usability and accessibility.